### PR TITLE
add shebang

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,5 +1,7 @@
+#!/usr/bin/env node
+
 const args = require('args');
-const { preparingPath, getFileData } = require('../src/utils');
+const { getFileData } = require('../src/utils');
 const { checkDuplications } = require('../src/check-duplications');
 
 const ALLOWED_TARGET_TYPES = ['package', 'yarn'];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yarn-lock-check-duplicates",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarn-lock-check-duplicates",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "main": "bin/check-duplicates.js",
   "bin": {
     "check-duplicates": "bin/index.js"

--- a/src/utils/preparing-path.js
+++ b/src/utils/preparing-path.js
@@ -5,7 +5,7 @@ exports.preparingPath = (target) => {
     const pathToUnixPath = os.platform() === 'win32' ? (str) => str.replace(/\\/g, '/') : (str) => str;
     const currentPath = pathToUnixPath(process.cwd());
 
-    if(target === 'package') {
+    if (target === 'package') {
         return join(currentPath, process.env.PATH_TO_FILE ? process.env.PATH_TO_FILE : '/package-lock.json')
     } else {
         return join(currentPath, process.env.PATH_TO_FILE ? process.env.PATH_TO_FILE : '/yarn.lock')

--- a/tests/spec/check-package/package-duplicate.test.ts
+++ b/tests/spec/check-package/package-duplicate.test.ts
@@ -7,35 +7,35 @@ describe('Check script which search duplicates in package-lock files', function 
 
 	describe('Invalid case', () => {
 		it('We check that duplicates will be found', function () {
-			exec(`PATH_TO_FILE="/tests/spec/check-package/resource/package-lock.json" node ${bin} -s @tinkoff-codeceptjs -t package`, { cwd: process.cwd() }, (err, stdout) => {
+			exec(`PATH_TO_FILE="/tests/spec/check-package/resource/package-lock.json" ${bin} -s @tinkoff-codeceptjs -t package`, { cwd: process.cwd() }, (err, stdout) => {
 				assert.equal(err?.code, 1);
 				assert.ok(stdout.includes('"name": "@tinkoff-codeceptjs/base-helper"'));
 				assert.ok(stdout.includes('"name": "@tinkoff-codeceptjs/utils"'));
 			});
 		});
 		it('We check that if the path to the file is incorrect, the error falls', function() {
-			exec(`PATH_TO_FILE="/tests/spec/check-package/package-lock.json" node ${bin} -s @tinkoff-codeceptjs -t package`, { cwd: process.cwd() }, (err, stdout, stderr) => {
+			exec(`PATH_TO_FILE="/tests/spec/check-package/package-lock.json" ${bin} -s @tinkoff-codeceptjs -t package`, { cwd: process.cwd() }, (err, stdout, stderr) => {
 				assert.equal(err?.code, 1);
 				assert.ok(stderr.includes(`Can't find "package-lock.json" file`));
 			});
 		});
 	
 		it('We check without specifying the scope', function() {
-			exec(`PATH_TO_FILE="/tests/spec/check-package/resource/package-lock.json" node ${bin}`, { cwd: process.cwd() }, (err, stdout, stderr) => {
+			exec(`PATH_TO_FILE="/tests/spec/check-package/resource/package-lock.json" ${bin}`, { cwd: process.cwd() }, (err, stdout, stderr) => {
 				assert.equal(err?.code, 1);
 				assert.ok(stderr.includes('Scope for search duplicates is not defined! Example: check-duplicates -s @babel'))
 			});
 		});
 
 		it('We check without specifying the target', function() {
-			exec(`PATH_TO_FILE="/tests/spec/check-package/resource/package-lock.json" node ${bin} -s @babel`, { cwd: process.cwd() }, (err, stdout, stderr) => {
+			exec(`PATH_TO_FILE="/tests/spec/check-package/resource/package-lock.json" ${bin} -s @babel`, { cwd: process.cwd() }, (err, stdout, stderr) => {
 				assert.equal(err?.code, 1);
 				assert.ok(stderr.includes('The target file for searching for duplicates is not defined! Example: check-duplicates -t package'))
 			});
 		});
 
 		it('We check with an invalid target', function() {
-			exec(`PATH_TO_FILE="/tests/spec/check-package/resource/package-lock.json" node ${bin} -s @babel -t test`, { cwd: process.cwd() }, (err, stdout, stderr) => {
+			exec(`PATH_TO_FILE="/tests/spec/check-package/resource/package-lock.json" ${bin} -s @babel -t test`, { cwd: process.cwd() }, (err, stdout, stderr) => {
 				assert.equal(err?.code, 1);
 				assert.ok(stderr.includes('The target file can only be of two types - package or yarn! "test" is not allowed'))
 			});
@@ -44,7 +44,7 @@ describe('Check script which search duplicates in package-lock files', function 
 	
 	describe('Valid case', () => {
 		it('We check with the file without repetitions', function() {
-			exec(`PATH_TO_FILE="/tests/spec/check-package/resource/valid-package-lock.json" node ${bin} -s @tinkoff-codeceptjs -t package`, { cwd: process.cwd() }, (err, stdout, stderr) => {
+			exec(`PATH_TO_FILE="/tests/spec/check-package/resource/valid-package-lock.json" ${bin} -s @tinkoff-codeceptjs -t package`, { cwd: process.cwd() }, (err, stdout, stderr) => {
 				assert.equal(err?.code, null);
 				assert.ok(stdout.includes('Packages installed from scope @tinkoff-codeceptjs has no duplicates'));
 			});

--- a/tests/spec/check-yarn/yarn-duplicate.test.ts
+++ b/tests/spec/check-yarn/yarn-duplicate.test.ts
@@ -7,34 +7,34 @@ describe('Check script which search duplicates in yarn.lock files', function () 
 
 	describe('Invalid case', () => {
 		it('We check that duplicates will be found', function () {
-			exec(`PATH_TO_FILE="/tests/spec/check-yarn/resource/yarn.lock" node ${bin} -s @babel -t yarn`, { cwd: process.cwd() }, (err, stdout, stderr) => {
+			exec(`PATH_TO_FILE="/tests/spec/check-yarn/resource/yarn.lock" ${bin} -s @babel -t yarn`, { cwd: process.cwd() }, (err, stdout, stderr) => {
                 assert.equal(err?.code, 1);
 				assert.ok(stdout.includes('"name": "@babel/helper-define-polyfill-provider"'));
 			});
 		});
 		it('We check that if the path to the file is incorrect, the error falls', function() {
-			exec(`PATH_TO_FILE="/tests/spec/check-yarn/yarn.lock" node ${bin} -s @babel -t yarn`, { cwd: process.cwd() }, (err, stdout, stderr) => {
+			exec(`PATH_TO_FILE="/tests/spec/check-yarn/yarn.lock" ${bin} -s @babel -t yarn`, { cwd: process.cwd() }, (err, stdout, stderr) => {
 				assert.equal(err?.code, 1);
 				assert.ok(stderr.includes(`Can't find "yarn.lock" file`));
 			});
 		});
 	
 		it('We check without specifying the scope', function() {
-			exec(`PATH_TO_FILE="/tests/spec/check-yarn/resource/yarn.lock" node ${bin}`, { cwd: process.cwd() }, (err, stdout, stderr) => {
+			exec(`PATH_TO_FILE="/tests/spec/check-yarn/resource/yarn.lock" ${bin}`, { cwd: process.cwd() }, (err, stdout, stderr) => {
 				assert.equal(err?.code, 1);
 				assert.ok(stderr.includes('Scope for search duplicates is not defined! Example: check-duplicates -s @babel'))
 			});
 		});
 
 		it('We check without specifying the target', function() {
-			exec(`PATH_TO_FILE="/tests/spec/check-yarn/resource/yarn.lock" node ${bin} -s @babel`, { cwd: process.cwd() }, (err, stdout, stderr) => {
+			exec(`PATH_TO_FILE="/tests/spec/check-yarn/resource/yarn.lock" ${bin} -s @babel`, { cwd: process.cwd() }, (err, stdout, stderr) => {
 				assert.equal(err?.code, 1);
 				assert.ok(stderr.includes('The target file for searching for duplicates is not defined! Example: check-duplicates -t package'))
 			});
 		});
 
 		it('We check with an invalid target', function() {
-			exec(`PATH_TO_FILE="/tests/spec/check-package/resource/package-lock.json" node ${bin} -s @babel -t test`, { cwd: process.cwd() }, (err, stdout, stderr) => {
+			exec(`PATH_TO_FILE="/tests/spec/check-package/resource/package-lock.json" ${bin} -s @babel -t test`, { cwd: process.cwd() }, (err, stdout, stderr) => {
 				assert.equal(err?.code, 1);
 				assert.ok(stderr.includes('The target file can only be of two types - package or yarn! "test" is not allowed'))
 			});
@@ -43,7 +43,7 @@ describe('Check script which search duplicates in yarn.lock files', function () 
 
     describe('Valid case', () => {
 		it('We check with the file without repetitions', function() {
-			exec(`PATH_TO_FILE="/tests/spec/check-yarn/resource/valid.yarn.lock" node ${bin} -s @babel -t yarn`, { cwd: process.cwd() }, (err, stdout, stderr) => {
+			exec(`PATH_TO_FILE="/tests/spec/check-yarn/resource/valid.yarn.lock" ${bin} -s @babel -t yarn`, { cwd: process.cwd() }, (err, stdout, stderr) => {
                 assert.equal(err?.code, null);
 				assert.ok(stdout.includes('Packages installed from scope @babel has no duplicates'));
 			});


### PR DESCRIPTION
Столкнулся с проблемой с версией yarn-lock-check-duplicates@1.2.2. Команда `yarn check-duplicates -s @babel -t yarn` выдает:
```
yarn run v1.22.17
$ /home/pavel/projects-work/****-****/node_modules/.bin/check-duplicates -s @babel -t yarn
/home/pavel/projects-work/****-****/node_modules/.bin/check-duplicates: 1: Syntax error: "(" unexpected
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
Проблему исправляет добавление шибенга в /bin/index.js, остальные изменения незначительные.